### PR TITLE
Setup Prettier to ensure a consistent coding style 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+
+after_script:
+  - npm run prettier

--- a/integration-tests/HydraClient.spec.ts
+++ b/integration-tests/HydraClient.spec.ts
@@ -1,44 +1,53 @@
-import HydraClient from "../src/HydraClient";
-import {run} from "../testing/AsyncHelper";
+import HydraClient from '../src/HydraClient';
+import { run } from '../testing/AsyncHelper';
 
-describe("Having a Hydra client", function() {
-    beforeEach(function() {
-        this.url = "http://localhost:3000/";
-        this.client = new HydraClient(true);
+describe('Having a Hydra client', function() {
+  beforeEach(function() {
+    this.url = 'http://localhost:3000/';
+    this.client = new HydraClient(true);
+  });
+
+  describe('while browsing the test website', function() {
+    beforeEach(
+      run(async function() {
+        this.apiDocumentation = await this.client.getApiDocumentation(this.url);
+      })
+    );
+
+    describe("and obtaining it's entry point as in use case 1.entry-point", function() {
+      beforeEach(
+        run(async function() {
+          this.entryPoint = await this.apiDocumentation.getEntryPoint();
+        })
+      );
+
+      it('should obtain two hypermedia controls', function() {
+        expect(this.entryPoint.hypermedia.length).toBe(2);
+      });
+
+      it('should obtain a schema:CreateAction operation', function() {
+        expect(
+          this.entryPoint.hypermedia.find(item => item.isA === 'Operation')
+        ).not.toBeNull();
+      });
+
+      it('should obtain a collection of events', function() {
+        expect(
+          this.entryPoint.hypermedia.find(
+            item => item.iri.match('/api/events$') && item.isA === 'Colletion'
+          )
+        ).not.toBeNull();
+      });
     });
 
-    describe("while browsing the test website", function() {
-        beforeEach(run(async function() {
-            this.apiDocumentation = await this.client.getApiDocumentation(this.url);
-        }));
+    describe("and obtaining it's API documentation as in use case 2.api-documentation", function() {
+      it('should obtain an API documentation', function() {
+        expect(this.apiDocumentation).not.toBeNull();
+      });
 
-        describe("and obtaining it's entry point as in use case 1.entry-point", function() {
-            beforeEach(run(async function() {
-                this.entryPoint = await this.apiDocumentation.getEntryPoint();
-            }));
-
-            it("should obtain two hypermedia controls", function() {
-                expect(this.entryPoint.hypermedia.length).toBe(2);
-            });
-
-            it("should obtain a schema:CreateAction operation", function() {
-                expect(this.entryPoint.hypermedia.find(item => item.isA === "Operation")).not.toBeNull();
-            });
-
-            it("should obtain a collection of events", function() {
-                expect(this.entryPoint.hypermedia.find(item => item.iri.match("\/api\/events$") && item.isA === "Colletion"))
-                    .not.toBeNull();
-            });
-        });
-
-        describe("and obtaining it's API documentation as in use case 2.api-documentation", function() {
-            it("should obtain an API documentation", function() {
-                expect(this.apiDocumentation).not.toBeNull();
-            });
-
-            it("should have access an entry point", function() {
-                expect(this.apiDocumentation.entryPoint.iri).toMatch(".*/api$");
-            });
-        });
+      it('should have access an entry point', function() {
+        expect(this.apiDocumentation.entryPoint.iri).toMatch('.*/api$');
+      });
     });
+  });
 });

--- a/integration-tests/server/server.ts
+++ b/integration-tests/server/server.ts
@@ -1,57 +1,67 @@
-import * as express from "express";
-const fs = require("fs");
+import * as express from 'express';
+const fs = require('fs');
 const serverPort = 3000;
 
-function setHeaders(path: string, response: express.Response, isJsonLd: boolean): boolean {
-    response.header("Content-Type", (isJsonLd ? "application/ld+json" : "text/plain"));
-    response.header("Access-Control-Allow-Origin", "*");
-    response.header("Access-Control-Allow-Methods", "GET");
-    response.header("Access-Control-Expose-Headers", "Link, Content-Type");
+function setHeaders(
+  path: string,
+  response: express.Response,
+  isJsonLd: boolean
+): boolean {
+  response.header(
+    'Content-Type',
+    isJsonLd ? 'application/ld+json' : 'text/plain'
+  );
+  response.header('Access-Control-Allow-Origin', '*');
+  response.header('Access-Control-Allow-Methods', 'GET');
+  response.header('Access-Control-Expose-Headers', 'Link, Content-Type');
 
-    let file = __dirname + path + ".headers";
-    if (!fs.existsSync(file)) {
-        return false;
-    }
-    fs.readFileSync(file, "utf8")
-        .replace("\r", "")
-        .split("\n")
-        .filter(header => header.length > 0)
-        .forEach(header => {
-            let name = header.split(":")[0];
-            let value = header.substr(name.length + 1).trim();
-            response.header(name, value);
-        });
+  let file = __dirname + path + '.headers';
+  if (!fs.existsSync(file)) {
+    return false;
+  }
+  fs
+    .readFileSync(file, 'utf8')
+    .replace('\r', '')
+    .split('\n')
+    .filter(header => header.length > 0)
+    .forEach(header => {
+      let name = header.split(':')[0];
+      let value = header.substr(name.length + 1).trim();
+      response.header(name, value);
+    });
 
-    return true;
+  return true;
 }
 
 function loadBody(path: string) {
-    let file = __dirname + path + (path.indexOf(".") === -1 ? ".jsonld" : "");
-    if (fs.existsSync(file)) {
-        return fs.readFileSync(file, "utf8");
-    }
+  let file = __dirname + path + (path.indexOf('.') === -1 ? '.jsonld' : '');
+  if (fs.existsSync(file)) {
+    return fs.readFileSync(file, 'utf8');
+  }
 
-    return null;
+  return null;
 }
 
 module.exports = {
-    "framework:hydra-testserver": [
-        "factory",
-        function framework(args, config, logger, helper) {
-            const log = logger.create("hydra-testserver");
-            log.info("Starting test server...");
-            const server = express();
-            server.disable("etag");
-            server.get("/*", (request, response) => {
-                let path = (request.path === "/" ? "/root" : request.path);
-                let body = loadBody(path);
-                if ((setHeaders(path, response, !!body)) || (body)) {
-                    response.status(200).send(body);
-                } else {
-                    response.status(404).send();
-                }
-            });
-            server.listen(serverPort, () => log.info("Hydra tests server is listening on port %d...", serverPort));
+  'framework:hydra-testserver': [
+    'factory',
+    function framework(args, config, logger, helper) {
+      const log = logger.create('hydra-testserver');
+      log.info('Starting test server...');
+      const server = express();
+      server.disable('etag');
+      server.get('/*', (request, response) => {
+        let path = request.path === '/' ? '/root' : request.path;
+        let body = loadBody(path);
+        if (setHeaders(path, response, !!body) || body) {
+          response.status(200).send(body);
+        } else {
+          response.status(404).send();
         }
-    ]
+      });
+      server.listen(serverPort, () =>
+        log.info('Hydra tests server is listening on port %d...', serverPort)
+      );
+    }
+  ]
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "test-watch": "node node_modules/karma/bin/karma start",
     "serve": "ts-node integration-tests/server/server.ts",
     "docs-html": "node node_modules/typedoc/bin/typedoc --excludeExternals --tsconfig tsconfig.docs.json --gitRevision master --out docs-html src",
-    "docs-md": "node node_modules/typedoc/bin/typedoc --theme markdown --mode file --excludeExternals --tsconfig tsconfig.docs.json --gitRevision master --out docs src"
+    "docs-md": "node node_modules/typedoc/bin/typedoc --theme markdown --mode file --excludeExternals --tsconfig tsconfig.docs.json --gitRevision master --out docs src",
+    "prettier": "node_modules/.bin/prettier --single-quote -l \"{src,testing,tests,integration-tests}/**/*.ts\"",
+    "prettier-fix": "node_modules/.bin/prettier --single-quote --write \"{src,testing,tests,integration-tests}/**/*.ts\""
   },
   "dependencies": {
     "isomorphic-fetch": "^2.2.1",
@@ -28,6 +30,7 @@
     "karma-sinon": "^1.0.5",
     "karma-source-map-support": "^1.2.0",
     "karma-typescript": "^3.0.2",
+    "prettier": "^1.5.3",
     "sinon": "^2.2.0",
     "ts-node": "^3.1.0",
     "typedoc": "^0.7.1",

--- a/src/ApiDocumentation.ts
+++ b/src/ApiDocumentation.ts
@@ -1,33 +1,30 @@
-import {IApiDocumentation} from "./DataModel/IApiDocumentation";
-import {IWebResource} from "./DataModel/IWebResource";
-import {IClass} from "./DataModel/IClass";
-import {IOperation} from "./DataModel/IOperation";
-import HydraClient from "./HydraClient";
-import {IResource} from "./DataModel/IResource";
+import { IApiDocumentation } from './DataModel/IApiDocumentation';
+import { IWebResource } from './DataModel/IWebResource';
+import { IClass } from './DataModel/IClass';
+import { IOperation } from './DataModel/IOperation';
+import HydraClient from './HydraClient';
+import { IResource } from './DataModel/IResource';
 
-export default class ApiDocumentation implements IApiDocumentation
-{
-    public title?: string;
+export default class ApiDocumentation implements IApiDocumentation {
+  public title?: string;
 
-    public description?: string;
+  public description?: string;
 
-    public supportedClasses: Array<IClass>;
+  public supportedClasses: Array<IClass>;
 
-    public supportedOperations: Array<IOperation>;
+  public supportedOperations: Array<IOperation>;
 
-    public entryPoint: string | IResource;
+  public entryPoint: string | IResource;
 
-    public client: HydraClient;
+  public client: HydraClient;
 
-    public ApiDocumentation()
-    {
-        this.supportedClasses = new Array<IClass>();
-        this.supportedOperations = new Array<IOperation>();
-        this.entryPoint = "";
-    }
+  public ApiDocumentation() {
+    this.supportedClasses = new Array<IClass>();
+    this.supportedOperations = new Array<IOperation>();
+    this.entryPoint = '';
+  }
 
-    public async getEntryPoint(): Promise<IWebResource>
-    {
-        return await this.client.getResource(this.entryPoint);
-    }
+  public async getEntryPoint(): Promise<IWebResource> {
+    return await this.client.getResource(this.entryPoint);
+  }
 }

--- a/src/DataModel/IApiDocumentation.ts
+++ b/src/DataModel/IApiDocumentation.ts
@@ -1,36 +1,35 @@
-import {IWebResource} from "./IWebResource";
-import {IClass} from "./IClass";
-import {IHypermedia} from "./IHypermedia";
-import {IResource} from "./IResource";
+import { IWebResource } from './IWebResource';
+import { IClass } from './IClass';
+import { IHypermedia } from './IHypermedia';
+import { IResource } from './IResource';
 
 /**
  * @interface Represents an abstract API documentation.
  */
-export interface IApiDocumentation extends IHypermedia
-{
-    /**
-     * @readonly Gets a title of this API documentation.
-     */
-    readonly title?: string;
+export interface IApiDocumentation extends IHypermedia {
+  /**
+   * @readonly Gets a title of this API documentation.
+   */
+  readonly title?: string;
 
-    /**
-     * @readonly Gets a description of this API documentation.
-     */
-    readonly description?: string;
+  /**
+   * @readonly Gets a description of this API documentation.
+   */
+  readonly description?: string;
 
-    /**
-     * @readonly Gets the supported classes by this API.
-     */
-    readonly supportedClasses: Array<IClass>;
+  /**
+   * @readonly Gets the supported classes by this API.
+   */
+  readonly supportedClasses: Array<IClass>;
 
-    /**
-     * @readonly Gets the Url of the entry point of the API.
-     */
-    readonly entryPoint: string | IResource;
+  /**
+   * @readonly Gets the Url of the entry point of the API.
+   */
+  readonly entryPoint: string | IResource;
 
-    /**
-     * Retrieves an API's entry point resource.
-     * @returns Promise<IWebResource>
-     */
-    getEntryPoint(): Promise<IWebResource>;
+  /**
+   * Retrieves an API's entry point resource.
+   * @returns Promise<IWebResource>
+   */
+  getEntryPoint(): Promise<IWebResource>;
 }

--- a/src/DataModel/IClass.ts
+++ b/src/DataModel/IClass.ts
@@ -1,9 +1,7 @@
-import {IHydraResource} from "./IHydraResource";
-import {IHypermedia} from "./IHypermedia";
+import { IHydraResource } from './IHydraResource';
+import { IHypermedia } from './IHypermedia';
 
 /**
  * @interface Represents a Hydra class
  */
-export interface IClass extends IHydraResource, IHypermedia
-{
-}
+export interface IClass extends IHydraResource, IHypermedia {}

--- a/src/DataModel/IHydraResource.ts
+++ b/src/DataModel/IHydraResource.ts
@@ -1,17 +1,17 @@
-import {IOperation} from "./IOperation";
-import {IResource} from "./IResource";
+import { IOperation } from './IOperation';
+import { IResource } from './IResource';
+
 /**
  * @interface Describes an abstract Hydra resource.
  */
-export interface IHydraResource extends IResource
-{
-    /**
-     * @readonly Gets classes a given resource is of.
-     */
-    readonly isA: Array<string>
+export interface IHydraResource extends IResource {
+  /**
+   * @readonly Gets classes a given resource is of.
+   */
+  readonly isA: Array<string>;
 
-    /**
-     * @readonly Gets operations that can be performed on that resource.
-     */
-    readonly operations: Array<IOperation>;
+  /**
+   * @readonly Gets operations that can be performed on that resource.
+   */
+  readonly operations: Array<IOperation>;
 }

--- a/src/DataModel/IHypermedia.ts
+++ b/src/DataModel/IHypermedia.ts
@@ -1,12 +1,11 @@
-import HydraClient from "../HydraClient";
+import HydraClient from '../HydraClient';
 
 /**
  * @interface Represents an abstract hypermedia control consumable within the Hydra client.
  */
-export interface IHypermedia
-{
-    /**
-     * @readonly Gets an instance of the Hydra client that was used to obtain that hypermedia control.
-     */
-    client: HydraClient;
+export interface IHypermedia {
+  /**
+   * @readonly Gets an instance of the Hydra client that was used to obtain that hypermedia control.
+   */
+  client: HydraClient;
 }

--- a/src/DataModel/IHypermediaProcessor.ts
+++ b/src/DataModel/IHypermediaProcessor.ts
@@ -1,28 +1,30 @@
-import {IWebResource} from "./IWebResource";
+import { IWebResource } from './IWebResource';
 
 /**
  * @interface Describes an abstract meta-data providing facility which translates from raw @link Response to an abstract data model.
  */
-export interface IHypermediaProcessor
-{
-    /**
-     * Gets supported media types.
-     * @returns {Array<string>}
-     */
-    supportedMediaTypes: Array<string>;
+export interface IHypermediaProcessor {
+  /**
+   * Gets supported media types.
+   * @returns {Array<string>}
+   */
+  supportedMediaTypes: Array<string>;
 
-    /**
-     * Parses a given raw response.
-     * @param {Response} response Raw fetch response holding data to be parsed.
-     * @returns {Promise<IWebResource>}
-     */
-    process(response: Response): Promise<IWebResource>;
+  /**
+   * Parses a given raw response.
+   * @param {Response} response Raw fetch response holding data to be parsed.
+   * @returns {Promise<IWebResource>}
+   */
+  process(response: Response): Promise<IWebResource>;
 
-    /**
-     * Parses a given raw response.
-     * @param {Response} response Raw fetch response holding data to be parsed.
-     * @param {boolean} removeFromPayload Instructs whether to remove the hypermedia from the response's body or not.
-     * @returns {Promise<IWebResource>}
-     */
-    process(response: Response, removeFromPayload: boolean): Promise<IWebResource>;
+  /**
+   * Parses a given raw response.
+   * @param {Response} response Raw fetch response holding data to be parsed.
+   * @param {boolean} removeFromPayload Instructs whether to remove the hypermedia from the response's body or not.
+   * @returns {Promise<IWebResource>}
+   */
+  process(
+    response: Response,
+    removeFromPayload: boolean
+  ): Promise<IWebResource>;
 }

--- a/src/DataModel/IOperation.ts
+++ b/src/DataModel/IOperation.ts
@@ -1,8 +1,6 @@
-import {IHydraResource} from "./IHydraResource";
+import { IHydraResource } from './IHydraResource';
 
 /**
  * @interface Describes an abstract Hydra operation.
  */
-export interface IOperation extends IHydraResource
-{
-}
+export interface IOperation extends IHydraResource {}

--- a/src/DataModel/IResource.ts
+++ b/src/DataModel/IResource.ts
@@ -1,10 +1,9 @@
 /**
  * @interface Describes an abstract RDF resource.
  */
-export interface IResource
-{
-    /**
-     * @readonly Gets an Iri of a resource.
-     */
-    readonly iri: string;
+export interface IResource {
+  /**
+   * @readonly Gets an Iri of a resource.
+   */
+  readonly iri: string;
 }

--- a/src/DataModel/IWebResource.ts
+++ b/src/DataModel/IWebResource.ts
@@ -1,12 +1,11 @@
-import {IHypermedia} from "./IHypermedia";
+import { IHypermedia } from './IHypermedia';
 
 /**
  * @interface Describes an abstract web resource.
  */
-export interface IWebResource extends Object
-{
-    /**
-     * @readonly Gets a collection of hypermedia controls.
-     */
-    readonly hypermedia: Array<IHypermedia>;
+export interface IWebResource extends Object {
+  /**
+   * @readonly Gets a collection of hypermedia controls.
+   */
+  readonly hypermedia: Array<IHypermedia>;
 }

--- a/src/DataModel/JsonLd/JsonLdHypermediaProcessor.ts
+++ b/src/DataModel/JsonLd/JsonLdHypermediaProcessor.ts
@@ -1,133 +1,162 @@
-import HydraClient from "../../HydraClient";
-import {IHypermediaProcessor} from "../IHypermediaProcessor";
-import {IWebResource} from "../IWebResource";
-import {hydra} from "../../namespaces";
-const jsonLd = require("jsonld").promises;
-const context = require("./context.json");
+import HydraClient from '../../HydraClient';
+import { IHypermediaProcessor } from '../IHypermediaProcessor';
+import { IWebResource } from '../IWebResource';
+import { hydra } from '../../namespaces';
+const jsonLd = require('jsonld').promises;
+const context = require('./context.json');
 
-export default class JsonLdHypermediaProcessor implements IHypermediaProcessor
-{
-    private static _mediaTypes = ["application/ld+json"];
-    private static _id = 0;
+export default class JsonLdHypermediaProcessor implements IHypermediaProcessor {
+  private static _mediaTypes = ['application/ld+json'];
+  private static _id = 0;
 
-    static initialize()
-    {
-        HydraClient.registerHypermediaProcessor(new JsonLdHypermediaProcessor());
+  static initialize() {
+    HydraClient.registerHypermediaProcessor(new JsonLdHypermediaProcessor());
+  }
+
+  public get supportedMediaTypes(): Array<string> {
+    return JsonLdHypermediaProcessor._mediaTypes;
+  }
+
+  public async process(
+    response: Response,
+    removeFromPayload: boolean = false
+  ): Promise<IWebResource> {
+    let payload = await response.json();
+    let hypermedia: any = null;
+    let result: any = payload;
+    if (!removeFromPayload) {
+      hypermedia = await jsonLd.frame(payload, context, { embed: '@link' });
+      hypermedia = hypermedia['@graph'];
+    } else {
+      result = await jsonLd.flatten(payload, null, { base: response.url });
+      hypermedia = JsonLdHypermediaProcessor.processHypermedia(
+        result,
+        new Array<any>(),
+        true
+      );
+      hypermedia = await jsonLd.frame(hypermedia, context, { embed: '@link' });
+      hypermedia = JsonLdHypermediaProcessor.removeReferencesFrom(
+        hypermedia['@graph']
+      );
     }
 
-    public get supportedMediaTypes(): Array<string>
-    {
-        return JsonLdHypermediaProcessor._mediaTypes;
+    Object.defineProperty(result, 'hypermedia', {
+      value: hypermedia,
+      enumerable: false
+    });
+    return result;
+  }
+
+  private static removeReferencesFrom(result: Array<any>): any {
+    for (let index = result.length - 1; index >= 0; index--) {
+      if (Object.keys(result[index]).length == 1 && result[index].iri) {
+        result.splice(index, 1);
+      }
     }
 
-    public async process(response: Response, removeFromPayload: boolean = false): Promise<IWebResource>
-    {
-        let payload = await response.json();
-        let hypermedia: any = null;
-        let result: any = payload;
-        if (!removeFromPayload)
-        {
-            hypermedia = await jsonLd.frame(payload, context, { embed: "@link" });
-            hypermedia = hypermedia["@graph"];
-        }
-        else
-        {
-            result = await jsonLd.flatten(payload, null, { base: response.url });
-            hypermedia = JsonLdHypermediaProcessor.processHypermedia(result, new Array<any>(), true);
-            hypermedia = await jsonLd.frame(hypermedia, context, { embed: "@link" });
-            hypermedia = JsonLdHypermediaProcessor.removeReferencesFrom(hypermedia["@graph"]);
-        }
+    return result;
+  }
 
-        Object.defineProperty(result, "hypermedia", { value: hypermedia, enumerable: false });
-        return result;
+  private static generateBlankNodeId(): string {
+    return '_:bnode' + ++JsonLdHypermediaProcessor._id;
+  }
+
+  private static processHypermedia(
+    payload: any,
+    result: Array<any> & { [key: string]: any },
+    removeFromPayload: boolean = false
+  ): any {
+    if (payload instanceof Array) {
+      return JsonLdHypermediaProcessor.processArray(
+        payload,
+        result,
+        removeFromPayload
+      );
     }
 
-    private static removeReferencesFrom(result: Array<any>): any
-    {
-        for (let index = result.length - 1; index >= 0; index--)
-        {
-            if ((Object.keys(result[index]).length == 1) && (result[index].iri))
-            {
-                result.splice(index, 1);
-            }
-        }
-
-        return result;
+    if (payload['@graph']) {
+      return JsonLdHypermediaProcessor.processHypermedia(
+        payload['@graph'],
+        result,
+        removeFromPayload
+      );
     }
 
-    private static generateBlankNodeId(): string
-    {
-        return "_:bnode" + (++JsonLdHypermediaProcessor._id);
+    return JsonLdHypermediaProcessor.processResource(
+      payload,
+      result,
+      removeFromPayload
+    );
+  }
+
+  private static processArray(
+    payload: any,
+    result: Array<any> & { [key: string]: any },
+    removeFromPayload: boolean = false
+  ) {
+    let toBeRemoved = new Array<any>();
+    for (let resource of payload) {
+      if (
+        !resource['@type'] ||
+        !!resource['@type'].find(item => item == hydra.EntryPoint) ||
+        !resource['@type'].every(item => item.indexOf(hydra.namespace) === 0)
+      ) {
+        JsonLdHypermediaProcessor.processHypermedia(
+          resource,
+          result,
+          removeFromPayload
+        );
+        continue;
+      }
+
+      Object.defineProperty(
+        result,
+        resource['@id'] || JsonLdHypermediaProcessor.generateBlankNodeId(),
+        { enumerable: false, value: resource }
+      );
+      result.push(resource);
+      if (removeFromPayload) {
+        toBeRemoved.push(resource);
+      }
     }
 
-    private static processHypermedia(payload: any, result: Array<any> & { [key: string]: any }, removeFromPayload: boolean = false): any
-    {
-        if (payload instanceof Array)
-        {
-            return JsonLdHypermediaProcessor.processArray(payload, result, removeFromPayload);
-        }
+    toBeRemoved.forEach(item => payload.splice(payload.indexOf(item), 1));
+    return result;
+  }
 
-        if (payload["@graph"])
-        {
-            return JsonLdHypermediaProcessor.processHypermedia(payload["@graph"], result, removeFromPayload);
-        }
-
-        return JsonLdHypermediaProcessor.processResource(payload, result, removeFromPayload);
+  private static processResource(
+    resource: any,
+    result: Array<any> & { [key: string]: any },
+    removeFromPayload: boolean
+  ): any {
+    let targetResource;
+    if (resource['@id'] && (targetResource = result[resource['@id']])) {
+      targetResource['@id'] = resource['@id'];
     }
 
-    private static processArray(payload: any, result: Array<any> & { [key: string]: any }, removeFromPayload: boolean = false)
-    {
-        let toBeRemoved = new Array<any>();
-        for (let resource of payload)
-        {
-            if (!resource["@type"] || !!resource["@type"].find(item => item == hydra.EntryPoint) ||
-                !resource["@type"].every(item => item.indexOf(hydra.namespace) === 0))
-            {
-                JsonLdHypermediaProcessor.processHypermedia(resource, result, removeFromPayload);
-                continue;
-            }
-
-            Object.defineProperty(result, resource["@id"] || JsonLdHypermediaProcessor.generateBlankNodeId(), { enumerable: false, value: resource });
-            result.push(resource);
-            if (removeFromPayload)
-            {
-                toBeRemoved.push(resource);
-            }
-        }
-
-        toBeRemoved.forEach(item => payload.splice(payload.indexOf(item), 1));
-        return result;
+    if (!targetResource) {
+      targetResource = {};
+      Object.defineProperty(
+        result,
+        JsonLdHypermediaProcessor.generateBlankNodeId(),
+        { enumerable: false, value: targetResource }
+      );
+      result.push(targetResource);
     }
 
-    private static processResource(resource: any, result: Array<any> & { [key: string]: any }, removeFromPayload: boolean): any
-    {
-        let targetResource;
-        if ((resource["@id"]) && (targetResource = result[resource["@id"]]))
-        {
-            targetResource["@id"] = resource["@id"];
+    for (let property of Object.keys(resource).filter(
+      property => property.charAt(0) !== '@'
+    )) {
+      if (property.indexOf(hydra.namespace) === 0) {
+        targetResource[property] = resource[property];
+        if (removeFromPayload) {
+          delete resource[property];
         }
-
-        if (!targetResource)
-        {
-            targetResource = {};
-            Object.defineProperty(result, JsonLdHypermediaProcessor.generateBlankNodeId(), { enumerable: false, value: targetResource });
-            result.push(targetResource);
-        }
-
-        for (let property of Object.keys(resource).filter(property => property.charAt(0) !== "@"))
-        {
-            if (property.indexOf(hydra.namespace) === 0)
-            {
-                targetResource[property] = resource[property];
-                if (removeFromPayload)
-                {
-                    delete resource[property];
-                }
-            }
-        }
-
-        return result;
+      }
     }
+
+    return result;
+  }
 }
 
 JsonLdHypermediaProcessor.initialize();

--- a/src/HydraClient.ts
+++ b/src/HydraClient.ts
@@ -1,156 +1,166 @@
-import {hydra} from "./namespaces";
-import {IHypermediaProcessor} from "./DataModel/IHypermediaProcessor";
-import {IApiDocumentation} from "./DataModel/IApiDocumentation";
-import {IWebResource} from "./DataModel/IWebResource";
-import ApiDocumentation from "./ApiDocumentation";
-import {IResource} from "./DataModel/IResource";
-const jsonld = require("jsonld");
-require("isomorphic-fetch");
+import { hydra } from './namespaces';
+import { IHypermediaProcessor } from './DataModel/IHypermediaProcessor';
+import { IApiDocumentation } from './DataModel/IApiDocumentation';
+import { IWebResource } from './DataModel/IWebResource';
+import ApiDocumentation from './ApiDocumentation';
+import { IResource } from './DataModel/IResource';
+const jsonld = require('jsonld');
+require('isomorphic-fetch');
 
 /**
  * @class HydraClient Heracles is a generic client for Hydra-powered Web APIs.
  *                    To learn more about Hydra please refer to {@link https://www.hydra-cg.com/spec/latest/core/}
  */
-export default class HydraClient
-{
-    private static _hypermediaProcessors = new Array<IHypermediaProcessor>();
-    private _removeHypermediaFromPayload;
+export default class HydraClient {
+  private static _hypermediaProcessors = new Array<IHypermediaProcessor>();
+  private _removeHypermediaFromPayload;
 
-    public static noUrlProvided = "There was no Url provided.";
-    public static apiDocumentationNotProvided = "API documentation not provided.";
-    public static noEntryPointDefined = "API documentation has no entry point defined.";
-    public static noHypermediaProcessor = "No hypermedia processor instance was provided for registration.";
-    public static invalidResponse = "Remote server responded with a status of ";
-    public static responseFormatNotSupported = "Response format is not supported.";
+  public static noUrlProvided = 'There was no Url provided.';
+  public static apiDocumentationNotProvided = 'API documentation not provided.';
+  public static noEntryPointDefined = 'API documentation has no entry point defined.';
+  public static noHypermediaProcessor = 'No hypermedia processor instance was provided for registration.';
+  public static invalidResponse = 'Remote server responded with a status of ';
+  public static responseFormatNotSupported = 'Response format is not supported.';
 
-    /**
-     * Initializes a new instance of the {@link HydraClient} class.
-     * @constructor
-     * @param removeHypermediaFromPayload {bool = true} Value indicating whether to remove hypermedia controls from the
-     *      resource's payload or leave it as is. Default is true.
-     */
-    public constructor(removeHypermediaFromPayload = false)
-    {
-        this._removeHypermediaFromPayload = removeHypermediaFromPayload;
+  /**
+   * Initializes a new instance of the {@link HydraClient} class.
+   * @constructor
+   * @param removeHypermediaFromPayload {bool = true} Value indicating whether to remove hypermedia controls from the
+   *      resource's payload or leave it as is. Default is true.
+   */
+  public constructor(removeHypermediaFromPayload = false) {
+    this._removeHypermediaFromPayload = removeHypermediaFromPayload;
+  }
+
+  /**
+   * Registers a hypermedia processor.
+   * @param {IHypermediaProcessor} hypermediaProcessor Hypermedia processor to be registered.
+   */
+  public static registerHypermediaProcessor(
+    hypermediaProcessor: IHypermediaProcessor
+  ) {
+    if (!hypermediaProcessor) {
+      throw new Error(HydraClient.noHypermediaProcessor);
     }
 
-    /**
-     * Registers a hypermedia processor.
-     * @param {IHypermediaProcessor} hypermediaProcessor Hypermedia processor to be registered.
-     */
-    public static registerHypermediaProcessor(hypermediaProcessor: IHypermediaProcessor)
-    {
-        if (!hypermediaProcessor)
-        {
-            throw new Error(HydraClient.noHypermediaProcessor);
-        }
+    HydraClient._hypermediaProcessors.push(hypermediaProcessor);
+  }
 
-        HydraClient._hypermediaProcessors.push(hypermediaProcessor);
+  /**
+   * Gets a hypermedia provider suitable for a given response.
+   * @param {Response} response Raw response to find hypermedia processor for.
+   * @returns {IHypermediaProcessor}
+   */
+  public getHypermediaProcessor(response: Response): IHypermediaProcessor {
+    return HydraClient._hypermediaProcessors.find(
+      provider =>
+        !!provider.supportedMediaTypes.find(
+          mediaType =>
+            response.headers.get('Content-Type').indexOf(mediaType) === 0
+        )
+    );
+  }
+
+  /**
+   * Obtains an API documentation.
+   * @param urlOrResource {string | IResource} Url or object with an iri property from which to obtain an API documentation.
+   * @returns {Promise<ApiDocumentation>}
+   */
+  public async getApiDocumentation(
+    urlOrResource: string | IResource
+  ): Promise<IApiDocumentation> {
+    let url = HydraClient.getUrl(urlOrResource);
+    let apiDocumentationUrl = await this.getApiDocumentationUrl(url);
+    let resource = await this.getResource(apiDocumentationUrl);
+    let apiDocumentation = <IApiDocumentation>resource.hypermedia.find(
+      hypermediaControl => (<any>hypermediaControl).entryPoint
+    );
+    if (!apiDocumentation) {
+      throw new Error(HydraClient.noEntryPointDefined);
     }
 
-    /**
-     * Gets a hypermedia provider suitable for a given response.
-     * @param {Response} response Raw response to find hypermedia processor for.
-     * @returns {IHypermediaProcessor}
-     */
-    public getHypermediaProcessor(response: Response): IHypermediaProcessor
-    {
-        return HydraClient._hypermediaProcessors.find(provider =>
-            !!provider.supportedMediaTypes.find(mediaType => response.headers.get("Content-Type").indexOf(mediaType) === 0));
+    apiDocumentation.client = this;
+    return Promise.resolve(
+      Object.create(
+        ApiDocumentation.prototype,
+        HydraClient.convertToPropertyDescriptorMap(apiDocumentation)
+      )
+    );
+  }
+
+  /**
+   * Obtains a representation of a resource.
+   * @param urlOrResource {string | IResource} Url or a {@link IResource} carrying an Iri of the resource to be obtained.
+   * @returns {Promise<IWebResource>}
+   */
+  public async getResource(
+    urlOrResource: string | IResource
+  ): Promise<IWebResource> {
+    let url = HydraClient.getUrl(urlOrResource);
+    let response = await fetch(url);
+    if (response.status !== 200) {
+      throw new Error(HydraClient.invalidResponse + response.status);
     }
 
-    /**
-     * Obtains an API documentation.
-     * @param urlOrResource {string | IResource} Url or object with an iri property from which to obtain an API documentation.
-     * @returns {Promise<ApiDocumentation>}
-     */
-    public async getApiDocumentation(urlOrResource: string | IResource): Promise<IApiDocumentation>
-    {
-        let url = HydraClient.getUrl(urlOrResource);
-        let apiDocumentationUrl = await this.getApiDocumentationUrl(url);
-        let resource = await this.getResource(apiDocumentationUrl);
-        let apiDocumentation = <IApiDocumentation>resource
-            .hypermedia.find(hypermediaControl => (<any>hypermediaControl).entryPoint);
-        if (!apiDocumentation)
-        {
-            throw new Error(HydraClient.noEntryPointDefined);
-        }
-
-        apiDocumentation.client = this;
-        return Promise.resolve(Object.create(ApiDocumentation.prototype, HydraClient.convertToPropertyDescriptorMap(apiDocumentation)));
+    let hypermediaProcessor = this.getHypermediaProcessor(response);
+    if (!hypermediaProcessor) {
+      throw new Error(HydraClient.responseFormatNotSupported);
     }
 
-    /**
-     * Obtains a representation of a resource.
-     * @param urlOrResource {string | IResource} Url or a {@link IResource} carrying an Iri of the resource to be obtained.
-     * @returns {Promise<IWebResource>}
-     */
-    public async getResource(urlOrResource: string | IResource): Promise<IWebResource>
-    {
-        let url = HydraClient.getUrl(urlOrResource);
-        let response = await fetch(url);
-        if (response.status !== 200)
-        {
-            throw new Error(HydraClient.invalidResponse + response.status);
-        }
+    return await hypermediaProcessor.process(
+      response,
+      this._removeHypermediaFromPayload
+    );
+  }
 
-        let hypermediaProcessor = this.getHypermediaProcessor(response);
-        if (!hypermediaProcessor)
-        {
-            throw new Error(HydraClient.responseFormatNotSupported);
-        }
-
-        return await hypermediaProcessor.process(response, this._removeHypermediaFromPayload);
+  private async getApiDocumentationUrl(url: string): Promise<string> {
+    let response = await fetch(url);
+    if (response.status !== 200) {
+      throw new Error(HydraClient.invalidResponse + response.status);
     }
 
-    private async getApiDocumentationUrl(url: string): Promise<string>
-    {
-        let response = await fetch(url);
-        if (response.status !== 200)
-        {
-            throw new Error(HydraClient.invalidResponse + response.status);
-        }
-
-        let link = response.headers.get("Link");
-        if (!link)
-        {
-            throw new Error(HydraClient.apiDocumentationNotProvided)
-        }
-
-        let result = link.match(`<([^>]+)>; rel="${hydra.apiDocumentation}"`);
-        if (!result)
-        {
-            throw new Error(HydraClient.apiDocumentationNotProvided)
-        }
-
-        return (!result[1].match(/^[a-z][a-z0-9+\-.]*:/) ? jsonld.prependBase(url.match(/^[a-z][a-z0-9+\-.]*:\/\/[^/]+/)[0], result[1]) : result[1]);
+    let link = response.headers.get('Link');
+    if (!link) {
+      throw new Error(HydraClient.apiDocumentationNotProvided);
     }
 
-    private static getUrl(urlOrResource: string | IResource): string
-    {
-        let url = (typeof(urlOrResource) === "object" ? urlOrResource.iri : urlOrResource);
-        if (!!!url)
-        {
-            throw new Error(HydraClient.noUrlProvided);
-        }
-
-        return url;
+    let result = link.match(`<([^>]+)>; rel="${hydra.apiDocumentation}"`);
+    if (!result) {
+      throw new Error(HydraClient.apiDocumentationNotProvided);
     }
 
-    private static convertToPropertyDescriptorMap(instance: any): PropertyDescriptorMap
-    {
-        let properties = {};
-        for (let property of Object.keys(instance))
-        {
-            let isFunction = typeof(instance[property] === "function");
-            properties[property] = {
-                value: instance[property],
-                writable: !isFunction,
-                enumerable: !isFunction,
-                configurable: false
-            };
-        }
+    return !result[1].match(/^[a-z][a-z0-9+\-.]*:/)
+      ? jsonld.prependBase(
+          url.match(/^[a-z][a-z0-9+\-.]*:\/\/[^/]+/)[0],
+          result[1]
+        )
+      : result[1];
+  }
 
-        return properties;
+  private static getUrl(urlOrResource: string | IResource): string {
+    let url =
+      typeof urlOrResource === 'object' ? urlOrResource.iri : urlOrResource;
+    if (!!!url) {
+      throw new Error(HydraClient.noUrlProvided);
     }
+
+    return url;
+  }
+
+  private static convertToPropertyDescriptorMap(
+    instance: any
+  ): PropertyDescriptorMap {
+    let properties = {};
+    for (let property of Object.keys(instance)) {
+      let isFunction = typeof (instance[property] === 'function');
+      properties[property] = {
+        value: instance[property],
+        writable: !isFunction,
+        enumerable: !isFunction,
+        configurable: false
+      };
+    }
+
+    return properties;
+  }
 }

--- a/src/namespaces.ts
+++ b/src/namespaces.ts
@@ -1,5 +1,5 @@
-export let hydra: any = new String("http://www.w3.org/ns/hydra/core#");
+export let hydra: any = new String('http://www.w3.org/ns/hydra/core#');
 hydra.namespace = hydra.toString();
-hydra.apiDocumentation = hydra + "apiDocumentation";
-hydra.ApiDocumentation = hydra + "ApiDocumentation";
-hydra.EntryPoint = hydra + "EntryPoint";
+hydra.apiDocumentation = hydra + 'apiDocumentation';
+hydra.ApiDocumentation = hydra + 'ApiDocumentation';
+hydra.EntryPoint = hydra + 'EntryPoint';

--- a/testing/AsyncHelper.ts
+++ b/testing/AsyncHelper.ts
@@ -1,7 +1,5 @@
-export function run(test)
-{
-    return function(done)
-    {
-        test.call(this).then(done, e => done.fail(e));
-    }
-};
+export function run(test) {
+  return function(done) {
+    test.call(this).then(done, e => done.fail(e));
+  };
+}

--- a/testing/ResponseHelper.ts
+++ b/testing/ResponseHelper.ts
@@ -1,26 +1,25 @@
-export function returnOk(url: string = "", body = {}, headers: any = {})
-{
-    return returnResponse(url, body, headers);
+export function returnOk(url: string = '', body = {}, headers: any = {}) {
+  return returnResponse(url, body, headers);
 }
 
-export function returnNotFound(url: string = "", body = {}, headers: any = {})
-{
-    return returnResponse(url, body, headers, 404);
+export function returnNotFound(url: string = '', body = {}, headers: any = {}) {
+  return returnResponse(url, body, headers, 404);
 }
 
-function returnResponse(url: string, body, headers: any = {}, status: number = 200)
-{
-    if (!headers["Content-Type"])
-    {
-        headers["Content-Type"] = "application/ld+json";
-    }
+function returnResponse(
+  url: string,
+  body,
+  headers: any = {},
+  status: number = 200
+) {
+  if (!headers['Content-Type']) {
+    headers['Content-Type'] = 'application/ld+json';
+  }
 
-    let result = new Response(
-        JSON.stringify(body),
-        {
-            status: status,
-            headers: headers
-        });
-    Object.defineProperty(result, "url", { value: url });
-    return result;
+  let result = new Response(JSON.stringify(body), {
+    status: status,
+    headers: headers
+  });
+  Object.defineProperty(result, 'url', { value: url });
+  return result;
 }

--- a/tests/ApiDocumentation.spec.ts
+++ b/tests/ApiDocumentation.spec.ts
@@ -1,31 +1,41 @@
-import * as sinon from "sinon";
-import {run} from "../testing/AsyncHelper";
-import {returnOk} from "../testing/ResponseHelper";
-import ApiDocumentation from "../src/ApiDocumentation";
+import * as sinon from 'sinon';
+import { run } from '../testing/AsyncHelper';
+import { returnOk } from '../testing/ResponseHelper';
+import ApiDocumentation from '../src/ApiDocumentation';
 
-describe("Given an instance of the ApiDocumentation class", function() {
+describe('Given an instance of the ApiDocumentation class', function() {
+  beforeEach(function() {
+    this.client = { getResource: sinon.stub() };
+    let setup = {
+      client: { value: this.client },
+      entryPoint: { value: 'http://temp.uri/api' }
+    };
+    this.apiDocumentation = Object.create(ApiDocumentation.prototype, setup);
+  });
+
+  describe('when obtaining an entry point', function() {
     beforeEach(function() {
-        this.client = { getResource: sinon.stub() };
-        let setup = {
-            client: { value: this.client },
-            entryPoint: { value: "http://temp.uri/api" }
-        };
-        this.apiDocumentation = Object.create(ApiDocumentation.prototype, setup);
+      this.client.getResource.returns((this.entryPoint = returnOk()));
     });
 
-    describe("when obtaining an entry point", function() {
-        beforeEach(function() {
-            this.client.getResource.returns(this.entryPoint = returnOk());
-        });
+    it(
+      'should call the client',
+      run(async function() {
+        await this.apiDocumentation.getEntryPoint();
 
-        it("should call the client", run(async function() {
-            await this.apiDocumentation.getEntryPoint();
+        expect(this.client.getResource).toHaveBeenCalledWith(
+          this.apiDocumentation.entryPoint
+        );
+      })
+    );
 
-            expect(this.client.getResource).toHaveBeenCalledWith(this.apiDocumentation.entryPoint);
-        }));
-
-        it("should provide a correct result", run(async function() {
-            expect(await this.apiDocumentation.getEntryPoint()).toBe(this.entryPoint);
-        }));
-    });
+    it(
+      'should provide a correct result',
+      run(async function() {
+        expect(await this.apiDocumentation.getEntryPoint()).toBe(
+          this.entryPoint
+        );
+      })
+    );
+  });
 });

--- a/tests/DataModel/JsonLd/JsonLdMetadataProvider.spec.ts
+++ b/tests/DataModel/JsonLd/JsonLdMetadataProvider.spec.ts
@@ -1,105 +1,137 @@
-import HydraClient from "../../../src/HydraClient";
-import {returnOk} from "../../../testing/ResponseHelper";
-import JsonLdHypermediaProcessor from "../../../src/DataModel/JsonLd/JsonLdHypermediaProcessor";
-import {run} from "../../../testing/AsyncHelper";
-const inputJsonLd = require("./input.json");
+import HydraClient from '../../../src/HydraClient';
+import { returnOk } from '../../../testing/ResponseHelper';
+import JsonLdHypermediaProcessor from '../../../src/DataModel/JsonLd/JsonLdHypermediaProcessor';
+import { run } from '../../../testing/AsyncHelper';
+const inputJsonLd = require('./input.json');
 
-describe("Given instance of the JsonLdHypermediaProcessor class", function() {
+describe('Given instance of the JsonLdHypermediaProcessor class', function() {
+  beforeEach(function() {
+    this.hypermediaProcessors = (<any>HydraClient)._hypermediaProcessors;
+    (<any>HydraClient)._hypermediaProcessors = [];
+    HydraClient.registerHypermediaProcessor(new JsonLdHypermediaProcessor());
+    this.hypermediaProcessor = new HydraClient().getHypermediaProcessor(
+      returnOk()
+    );
+  });
+
+  it('should get itself registered', function() {
+    expect(this.hypermediaProcessor).toEqual(
+      jasmine.any(JsonLdHypermediaProcessor)
+    );
+  });
+
+  it('should expose supported media types', function() {
+    expect(this.hypermediaProcessor.supportedMediaTypes).toEqual([
+      'application/ld+json'
+    ]);
+  });
+
+  describe('when parsing', function() {
     beforeEach(function() {
-        this.hypermediaProcessors = (<any>HydraClient)._hypermediaProcessors;
-        (<any>HydraClient)._hypermediaProcessors = [];
-        HydraClient.registerHypermediaProcessor(new JsonLdHypermediaProcessor());
-        this.hypermediaProcessor = new HydraClient().getHypermediaProcessor(returnOk());
+      this.response = returnOk('http://temp.uri/', inputJsonLd);
     });
 
-    it("should get itself registered", function() {
-        expect(this.hypermediaProcessor).toEqual(jasmine.any(JsonLdHypermediaProcessor));
+    describe('without removing hypermedia controls', function() {
+      it(
+        'should process data',
+        run(async function() {
+          let result = await this.hypermediaProcessor.process(
+            this.response,
+            false
+          );
+
+          expect(result).toEqual(inputJsonLd);
+        })
+      );
+
+      it(
+        'should separate hypermedia',
+        run(async function() {
+          let result = await this.hypermediaProcessor.process(
+            this.response,
+            false
+          );
+
+          expect(result.hypermedia).toEqual([
+            {
+              iri: 'http://temp.uri/api/events',
+              isA: 'Collection',
+              totalItems: 1,
+              members: [
+                {
+                  iri: 'http://temp.uri/api/events/1',
+                  'http://schema.org/endDate': '2017-04-19',
+                  'http://schema.org/eventDescription': 'Some event 1',
+                  'http://schema.org/eventName': 'Event 1',
+                  'http://schema.org/startDate': '2017-04-19'
+                }
+              ]
+            },
+            {
+              iri: 'http://temp.uri/api/events/1',
+              'http://schema.org/endDate': '2017-04-19',
+              'http://schema.org/eventDescription': 'Some event 1',
+              'http://schema.org/eventName': 'Event 1',
+              'http://schema.org/startDate': '2017-04-19'
+            },
+            {
+              iri: 'some:named.graph'
+            }
+          ]);
+        })
+      );
     });
 
-    it("should expose supported media types", function() {
-        expect(this.hypermediaProcessor.supportedMediaTypes).toEqual(["application/ld+json"]);
+    describe('and removing hypermedia controls', function() {
+      it(
+        'should process data',
+        run(async function() {
+          let result = await this.hypermediaProcessor.process(
+            this.response,
+            true
+          );
+
+          expect(result).toEqual([
+            {
+              '@id': 'some:named.graph',
+              '@graph': [
+                {
+                  '@id': 'http://temp.uri/api/events/1',
+                  'http://schema.org/eventName': [{ '@value': 'Event 1' }],
+                  'http://schema.org/eventDescription': [
+                    { '@value': 'Some event 1' }
+                  ],
+                  'http://schema.org/startDate': [{ '@value': '2017-04-19' }],
+                  'http://schema.org/endDate': [{ '@value': '2017-04-19' }]
+                }
+              ]
+            }
+          ]);
+        })
+      );
+
+      it(
+        'should separate hypermedia',
+        run(async function() {
+          let result = await this.hypermediaProcessor.process(
+            this.response,
+            true
+          );
+
+          expect(result.hypermedia).toEqual([
+            {
+              iri: 'http://temp.uri/api/events',
+              isA: 'Collection',
+              totalItems: 1,
+              members: [{ iri: 'http://temp.uri/api/events/1' }]
+            }
+          ]);
+        })
+      );
     });
+  });
 
-    describe("when parsing", function() {
-        beforeEach(function() {
-            this.response = returnOk("http://temp.uri/", inputJsonLd);
-        });
-
-        describe("without removing hypermedia controls", function() {
-            it("should process data", run(async function() {
-                let result = await this.hypermediaProcessor.process(this.response, false);
-
-                expect(result).toEqual(inputJsonLd);
-            }));
-
-            it("should separate hypermedia", run(async function() {
-                let result = await this.hypermediaProcessor.process(this.response, false);
-
-                expect(result.hypermedia).toEqual([
-                    {
-                        iri: "http://temp.uri/api/events",
-                        isA: "Collection",
-                        totalItems: 1,
-                        members: [
-                            {
-                                iri: "http://temp.uri/api/events/1",
-                                "http://schema.org/endDate": "2017-04-19",
-                                "http://schema.org/eventDescription": "Some event 1",
-                                "http://schema.org/eventName": "Event 1",
-                                "http://schema.org/startDate": "2017-04-19"
-                            }
-                        ]
-                    }, {
-                        iri: "http://temp.uri/api/events/1",
-                        "http://schema.org/endDate": "2017-04-19",
-                        "http://schema.org/eventDescription": "Some event 1",
-                        "http://schema.org/eventName": "Event 1",
-                        "http://schema.org/startDate": "2017-04-19"
-                    }, {
-                        iri: 'some:named.graph'
-                    }
-                ]);
-            }));
-        });
-
-        describe("and removing hypermedia controls", function() {
-            it("should process data", run(async function() {
-                let result = await this.hypermediaProcessor.process(this.response, true);
-
-                expect(result).toEqual([
-                    {
-                        "@id": "some:named.graph",
-                        "@graph": [
-                            {
-                                "@id": "http://temp.uri/api/events/1",
-                                "http://schema.org/eventName": [{ "@value": "Event 1" }],
-                                "http://schema.org/eventDescription": [{ "@value": "Some event 1" }],
-                                "http://schema.org/startDate": [{ "@value": "2017-04-19" }],
-                                "http://schema.org/endDate": [{ "@value": "2017-04-19" }]
-                            }
-                        ]
-                    }
-                ]);
-            }));
-
-            it("should separate hypermedia", run(async function() {
-                let result = await this.hypermediaProcessor.process(this.response, true);
-
-                expect(result.hypermedia).toEqual([
-                    {
-                        "iri": "http://temp.uri/api/events",
-                        "isA": "Collection",
-                        "totalItems": 1,
-                        "members": [
-                            { "iri": "http://temp.uri/api/events/1" }
-                        ]
-                    }
-                ]);
-            }));
-        });
-    });
-
-    afterEach(function() {
-        (<any>HydraClient)._hypermediaProcessors = this.hypermediaProcessors;
-    });
+  afterEach(function() {
+    (<any>HydraClient)._hypermediaProcessors = this.hypermediaProcessors;
+  });
 });

--- a/tests/HydraClient.spec.ts
+++ b/tests/HydraClient.spec.ts
@@ -1,216 +1,348 @@
-import * as sinon from "sinon";
-import {run} from "../testing/AsyncHelper";
-import {returnOk, returnNotFound} from "../testing/ResponseHelper";
-import {hydra} from "../src/namespaces";
-import HydraClient from "../src/HydraClient";
-import ApiDocumentation from "../src/ApiDocumentation";
+import * as sinon from 'sinon';
+import { run } from '../testing/AsyncHelper';
+import { returnOk, returnNotFound } from '../testing/ResponseHelper';
+import { hydra } from '../src/namespaces';
+import HydraClient from '../src/HydraClient';
+import ApiDocumentation from '../src/ApiDocumentation';
 
-describe("Given an instance of the HydraClient class", function() {
-    beforeEach(function() {
-        this.baseUrl = "http://temp.uri/";
-        this.hypermediaProcessor = {
-            supportedMediaTypes: ["application/ld+json"],
-            process: sinon.stub()
-        };
-        this.client = new HydraClient(true);
-        this.hypermediaProcessors = (<any>HydraClient)._hypermediaProcessors;
-        (<any>HydraClient)._hypermediaProcessors = [];
-        HydraClient.registerHypermediaProcessor(this.hypermediaProcessor);
-        this.fetch = sinon.stub(window, "fetch");
+describe('Given an instance of the HydraClient class', function() {
+  beforeEach(function() {
+    this.baseUrl = 'http://temp.uri/';
+    this.hypermediaProcessor = {
+      supportedMediaTypes: ['application/ld+json'],
+      process: sinon.stub()
+    };
+    this.client = new HydraClient(true);
+    this.hypermediaProcessors = (<any>HydraClient)._hypermediaProcessors;
+    (<any>HydraClient)._hypermediaProcessors = [];
+    HydraClient.registerHypermediaProcessor(this.hypermediaProcessor);
+    this.fetch = sinon.stub(window, 'fetch');
+  });
+
+  it('should create an instance', function() {
+    expect(this.client).toEqual(jasmine.any(HydraClient));
+  });
+
+  it('should register a hypermedia processor', function() {
+    expect(this.client.getHypermediaProcessor(returnOk())).toBe(
+      this.hypermediaProcessor
+    );
+  });
+
+  describe('when obtaining an API documentation', function() {
+    describe('and no valid Url is given', function() {
+      it(
+        'should throw',
+        run(async function() {
+          try {
+            await this.client.getApiDocumentation({ iri: null });
+          } catch (e) {
+            expect(e.message).toBe(HydraClient.noUrlProvided);
+          }
+        })
+      );
     });
 
-    it("should create an instance", function() {
-        expect(this.client).toEqual(jasmine.any(HydraClient));
+    describe("of which site's main document is not found", function() {
+      beforeEach(function() {
+        this.fetch
+          .withArgs(this.baseUrl)
+          .returns(Promise.resolve(returnNotFound()));
+      });
+
+      it(
+        'should throw',
+        run(async function() {
+          try {
+            await this.client.getApiDocumentation(this.baseUrl);
+          } catch (e) {
+            expect(e.message).toBe(HydraClient.invalidResponse + '404');
+          }
+        })
+      );
     });
 
-    it("should register a hypermedia processor", function() {
-        expect(this.client.getHypermediaProcessor(returnOk())).toBe(this.hypermediaProcessor);
+    describe('which has no LINK header returned', function() {
+      beforeEach(function() {
+        this.fetch.withArgs(this.baseUrl).returns(Promise.resolve(returnOk()));
+      });
+
+      it(
+        'should throw',
+        run(async function() {
+          try {
+            await this.client.getApiDocumentation(this.baseUrl);
+          } catch (e) {
+            expect(e.message).toBe(HydraClient.apiDocumentationNotProvided);
+          }
+        })
+      );
     });
 
-    describe("when obtaining an API documentation", function() {
-        describe("and no valid Url is given", function() {
-            it("should throw", run(async function() {
-                try { await this.client.getApiDocumentation({ iri: null }); }
-                catch (e) { expect(e.message).toBe(HydraClient.noUrlProvided); }
-            }));
-        });
+    describe('which is not provided within the LINK header', function() {
+      beforeEach(function() {
+        this.urlResponse = returnOk(
+          this.baseUrl,
+          {},
+          { Link: `<${this.baseUrl}api/documentation>; rel="next"` }
+        );
+        this.fetch
+          .withArgs(this.baseUrl)
+          .returns(Promise.resolve(this.urlResponse));
+      });
 
-        describe("of which site's main document is not found", function() {
-            beforeEach(function() {
-                this.fetch.withArgs(this.baseUrl).returns(Promise.resolve(returnNotFound()));
-            });
-
-            it("should throw", run(async function() {
-                try { await this.client.getApiDocumentation(this.baseUrl); }
-                catch (e) { expect(e.message).toBe(HydraClient.invalidResponse + "404"); }
-            }));
-        });
-
-        describe("which has no LINK header returned", function() {
-            beforeEach(function() {
-                this.fetch.withArgs(this.baseUrl).returns(Promise.resolve(returnOk()));
-            });
-
-            it("should throw", run(async function() {
-                try { await this.client.getApiDocumentation(this.baseUrl); }
-                catch (e) { expect(e.message).toBe(HydraClient.apiDocumentationNotProvided); }
-            }));
-        });
-
-        describe("which is not provided within the LINK header", function() {
-            beforeEach(function() {
-                this.urlResponse = returnOk(this.baseUrl, {}, { "Link": `<${this.baseUrl}api/documentation>; rel="next"` });
-                this.fetch.withArgs(this.baseUrl).returns(Promise.resolve(this.urlResponse));
-            });
-
-            it("should throw", run(async function() {
-                try { this.client.getApiDocumentation(this.baseUrl); }
-                catch (e) { expect(e.message).toBe(HydraClient.apiDocumentationNotProvided); }
-            }));
-        });
-
-        describe("from a valid site", function() {
-            beforeEach(function() {
-                this.urlResponse = returnOk(this.baseUrl, {}, { "Link": `<${this.baseUrl}api/documentation>; rel="${hydra.apiDocumentation}"` });
-                this.fetch.withArgs(this.baseUrl).returns(Promise.resolve(this.urlResponse));
-            });
-
-            describe("and that documentation is not found", function() {
-                beforeEach(function() {
-                    this.apiDocumentationResponse = returnNotFound();
-                    this.fetch.withArgs(`${this.baseUrl}api/documentation`).returns(this.apiDocumentationResponse);
-                });
-
-                it("should throw", run(async function() {
-                    try { this.client.getApiDocumentation({ iri: this.baseUrl }); }
-                    catch (e) { expect(e.message).toBe(HydraClient.invalidResponse); }
-                }));
-            });
-
-            describe("and that documentation is provided in an unsupported format", function() {
-                beforeEach(function() {
-                    let apiDocumentationUrl = `${this.baseUrl}api/documentation`;
-                    this.apiDocumentationResponse = returnOk(apiDocumentationUrl, {}, { "Content-Type": "text/turtle" });
-                    this.fetch.withArgs(apiDocumentationUrl).returns(this.apiDocumentationResponse);
-                });
-
-                it("should throw", run(async function() {
-                    try { this.client.getApiDocumentation({ iri: this.baseUrl }); }
-                    catch (e) { expect(e.message).toBe(HydraClient.responseFormatNotSupported); }
-                }));
-            });
-
-            describe("and that documentation has no entry point provided", function() {
-                beforeEach(function() {
-                    this.apiDocumentationResponse = returnOk();
-                    this.fetch.withArgs(`${this.baseUrl}api/documentation`).returns(this.apiDocumentationResponse);
-                    this.hypermediaProcessor.process.returns({});
-                });
-
-                it("should throw", run(async function() {
-                    try { this.client.getApiDocumentation({ iri: this.baseUrl }); }
-                    catch (e) { expect(e.message).toBe(HydraClient.noEntryPointDefined); }
-                }));
-            });
-
-            describe("which is provided correctly", function() {
-                beforeEach(function() {
-                    let apiDocumentationUrl = `${this.baseUrl}api/documentation`;
-                    this.apiDocumentation = { entryPoint: `${this.baseUrl}api` };
-                    this.data = [this.apiDocumentation];
-                    this.apiDocumentationResponse = returnOk(apiDocumentationUrl, this.data);
-                    this.fetch.withArgs(apiDocumentationUrl).returns(this.apiDocumentationResponse);
-                    this.hypermediaProcessor.process.returns(Promise.resolve({ hypermedia: this.data }));
-                });
-
-                it("should call the given site url", run(async function() {
-                    await this.client.getApiDocumentation(this.baseUrl);
-
-                    expect(this.fetch).toHaveBeenCalledWith(this.baseUrl);
-                }));
-
-                it("should fetch the API documentation", run(async function() {
-                    await this.client.getApiDocumentation(this.baseUrl);
-
-                    expect(this.fetch).toHaveBeenCalledWith(`${this.baseUrl}api/documentation`);
-                }));
-
-                it("should process API documentation with a hypermedia processor", run(async function() {
-                    await this.client.getApiDocumentation(this.baseUrl);
-
-                    (<any>expect(this.hypermediaProcessor.process)).toHaveBeenCalledWith(this.apiDocumentationResponse);
-                }));
-
-                it("should return a correct ApiDocumentation instance", run(async function() {
-                    let result = await this.client.getApiDocumentation(this.baseUrl);
-
-                    expect(result).toEqual(jasmine.any(ApiDocumentation));
-                    expect(result.client).toBe(this.client);
-                }));
-            });
-        });
+      it(
+        'should throw',
+        run(async function() {
+          try {
+            this.client.getApiDocumentation(this.baseUrl);
+          } catch (e) {
+            expect(e.message).toBe(HydraClient.apiDocumentationNotProvided);
+          }
+        })
+      );
     });
 
-    describe("when fetching a resource", function() {
+    describe('from a valid site', function() {
+      beforeEach(function() {
+        this.urlResponse = returnOk(
+          this.baseUrl,
+          {},
+          {
+            Link: `<${this
+              .baseUrl}api/documentation>; rel="${hydra.apiDocumentation}"`
+          }
+        );
+        this.fetch
+          .withArgs(this.baseUrl)
+          .returns(Promise.resolve(this.urlResponse));
+      });
+
+      describe('and that documentation is not found', function() {
         beforeEach(function() {
-            this.resourceUrl = "http://temp.uri/resource2";
+          this.apiDocumentationResponse = returnNotFound();
+          this.fetch
+            .withArgs(`${this.baseUrl}api/documentation`)
+            .returns(this.apiDocumentationResponse);
         });
 
-        describe("and no valid url was provided", function() {
-            it("should throw", run(async function() {
-                try { await this.client.getResource({ iri: null }); }
-                catch (e) { expect(e.message).toBe(HydraClient.noUrlProvided); }
-            }));
+        it(
+          'should throw',
+          run(async function() {
+            try {
+              this.client.getApiDocumentation({ iri: this.baseUrl });
+            } catch (e) {
+              expect(e.message).toBe(HydraClient.invalidResponse);
+            }
+          })
+        );
+      });
+
+      describe('and that documentation is provided in an unsupported format', function() {
+        beforeEach(function() {
+          let apiDocumentationUrl = `${this.baseUrl}api/documentation`;
+          this.apiDocumentationResponse = returnOk(
+            apiDocumentationUrl,
+            {},
+            { 'Content-Type': 'text/turtle' }
+          );
+          this.fetch
+            .withArgs(apiDocumentationUrl)
+            .returns(this.apiDocumentationResponse);
         });
 
-        describe("and that resource was not found", function() {
-            beforeEach(function() {
-                this.fetch.withArgs(this.resourceUrl).returns(Promise.resolve(returnNotFound()));
-            });
+        it(
+          'should throw',
+          run(async function() {
+            try {
+              this.client.getApiDocumentation({ iri: this.baseUrl });
+            } catch (e) {
+              expect(e.message).toBe(HydraClient.responseFormatNotSupported);
+            }
+          })
+        );
+      });
 
-            it("should throw", run(async function() {
-                try { await this.client.getResource(this.resourceUrl); }
-                catch (e) { expect(e.message).toBe(HydraClient.invalidResponse + "404"); }
-            }));
+      describe('and that documentation has no entry point provided', function() {
+        beforeEach(function() {
+          this.apiDocumentationResponse = returnOk();
+          this.fetch
+            .withArgs(`${this.baseUrl}api/documentation`)
+            .returns(this.apiDocumentationResponse);
+          this.hypermediaProcessor.process.returns({});
         });
 
-        describe("and that resource was provided in an unsupported format", function() {
-            beforeEach(function() {
-                this.resourceResponse = returnOk(this.resourceUrl, {}, { "Content-Type": "text/turtle" });
-                this.fetch.withArgs(this.resourceUrl).returns(Promise.resolve(this.resourceResponse));
-            });
+        it(
+          'should throw',
+          run(async function() {
+            try {
+              this.client.getApiDocumentation({ iri: this.baseUrl });
+            } catch (e) {
+              expect(e.message).toBe(HydraClient.noEntryPointDefined);
+            }
+          })
+        );
+      });
 
-            it("should throw", run(async function() {
-                try { await this.client.getResource(this.resourceUrl); }
-                catch (e) { expect(e.message).toBe(HydraClient.responseFormatNotSupported); }
-            }));
+      describe('which is provided correctly', function() {
+        beforeEach(function() {
+          let apiDocumentationUrl = `${this.baseUrl}api/documentation`;
+          this.apiDocumentation = { entryPoint: `${this.baseUrl}api` };
+          this.data = [this.apiDocumentation];
+          this.apiDocumentationResponse = returnOk(
+            apiDocumentationUrl,
+            this.data
+          );
+          this.fetch
+            .withArgs(apiDocumentationUrl)
+            .returns(this.apiDocumentationResponse);
+          this.hypermediaProcessor.process.returns(
+            Promise.resolve({ hypermedia: this.data })
+          );
         });
 
-        describe("and that resource was provided correctly", function() {
-            beforeEach(function() {
-                this.resource = { hypermedia: {} };
-                this.resourceResponse = returnOk(this.resource);
-                this.fetch.withArgs(this.resourceUrl).returns(Promise.resolve(this.resourceResponse));
-                this.hypermediaProcessor.process.withArgs(this.resourceResponse, true)
-                    .returns(Promise.resolve(this.resource));
-            });
+        it(
+          'should call the given site url',
+          run(async function() {
+            await this.client.getApiDocumentation(this.baseUrl);
 
-            it("should process the response", run(async function() {
-                await this.client.getResource(this.resourceUrl);
+            expect(this.fetch).toHaveBeenCalledWith(this.baseUrl);
+          })
+        );
 
-                expect(this.hypermediaProcessor.process).toHaveBeenCalledWith(this.resourceResponse, true);
-            }));
+        it(
+          'should fetch the API documentation',
+          run(async function() {
+            await this.client.getApiDocumentation(this.baseUrl);
 
-            it("should return a correct result", run(async function() {
-                let result = await this.client.getResource(this.resourceUrl);
+            expect(this.fetch).toHaveBeenCalledWith(
+              `${this.baseUrl}api/documentation`
+            );
+          })
+        );
 
-                expect(result).toBe(this.resource);
-            }));
-        });
+        it(
+          'should process API documentation with a hypermedia processor',
+          run(async function() {
+            await this.client.getApiDocumentation(this.baseUrl);
+
+            (<any>expect(
+              this.hypermediaProcessor.process
+            )).toHaveBeenCalledWith(this.apiDocumentationResponse);
+          })
+        );
+
+        it(
+          'should return a correct ApiDocumentation instance',
+          run(async function() {
+            let result = await this.client.getApiDocumentation(this.baseUrl);
+
+            expect(result).toEqual(jasmine.any(ApiDocumentation));
+            expect(result.client).toBe(this.client);
+          })
+        );
+      });
+    });
+  });
+
+  describe('when fetching a resource', function() {
+    beforeEach(function() {
+      this.resourceUrl = 'http://temp.uri/resource2';
     });
 
-    afterEach(function() {
-        (<any>HydraClient)._hypermediaProcessors = this.hypermediaProcessors;
-        this.fetch.restore();
+    describe('and no valid url was provided', function() {
+      it(
+        'should throw',
+        run(async function() {
+          try {
+            await this.client.getResource({ iri: null });
+          } catch (e) {
+            expect(e.message).toBe(HydraClient.noUrlProvided);
+          }
+        })
+      );
     });
+
+    describe('and that resource was not found', function() {
+      beforeEach(function() {
+        this.fetch
+          .withArgs(this.resourceUrl)
+          .returns(Promise.resolve(returnNotFound()));
+      });
+
+      it(
+        'should throw',
+        run(async function() {
+          try {
+            await this.client.getResource(this.resourceUrl);
+          } catch (e) {
+            expect(e.message).toBe(HydraClient.invalidResponse + '404');
+          }
+        })
+      );
+    });
+
+    describe('and that resource was provided in an unsupported format', function() {
+      beforeEach(function() {
+        this.resourceResponse = returnOk(
+          this.resourceUrl,
+          {},
+          { 'Content-Type': 'text/turtle' }
+        );
+        this.fetch
+          .withArgs(this.resourceUrl)
+          .returns(Promise.resolve(this.resourceResponse));
+      });
+
+      it(
+        'should throw',
+        run(async function() {
+          try {
+            await this.client.getResource(this.resourceUrl);
+          } catch (e) {
+            expect(e.message).toBe(HydraClient.responseFormatNotSupported);
+          }
+        })
+      );
+    });
+
+    describe('and that resource was provided correctly', function() {
+      beforeEach(function() {
+        this.resource = { hypermedia: {} };
+        this.resourceResponse = returnOk(this.resource);
+        this.fetch
+          .withArgs(this.resourceUrl)
+          .returns(Promise.resolve(this.resourceResponse));
+        this.hypermediaProcessor.process
+          .withArgs(this.resourceResponse, true)
+          .returns(Promise.resolve(this.resource));
+      });
+
+      it(
+        'should process the response',
+        run(async function() {
+          await this.client.getResource(this.resourceUrl);
+
+          expect(this.hypermediaProcessor.process).toHaveBeenCalledWith(
+            this.resourceResponse,
+            true
+          );
+        })
+      );
+
+      it(
+        'should return a correct result',
+        run(async function() {
+          let result = await this.client.getResource(this.resourceUrl);
+
+          expect(result).toBe(this.resource);
+        })
+      );
+    });
+  });
+
+  afterEach(function() {
+    (<any>HydraClient)._hypermediaProcessors = this.hypermediaProcessors;
+    this.fetch.restore();
+  });
 });


### PR DESCRIPTION
This is a variation of #10 using Prettier instead of TSLint. I updated all existing files to show the changes.

We could also use Prettier and TSLint together (see [tslint-config-prettier](https://www.npmjs.com/package/tslint-config-prettier))