### PR TITLE
Run Travis also with NodeJS 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
 language: node_js
 node_js:
   - node
+  - 8
   - 7
   - 6
   - 5

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "karma-jasmine-sinon": "^1.0.4",
     "karma-sinon": "^1.0.5",
     "karma-source-map-support": "^1.2.0",
-    "karma-typescript": "^3.0.2",
+    "karma-typescript": "3.0.8",
     "prettier": "^1.7.3",
     "sinon": "^2.2.0",
     "ts-node": "^3.1.0",


### PR DESCRIPTION
To ensure everything works with that version too. Also fixed karma-typescript to 3.0.8 as NodeJS 5 support broke with version 3.0.9.