### PR TITLE
Removed Array extension from TypesCollection to resolve #26

### DIFF
--- a/src/DataModel/Collections/TypesCollection.ts
+++ b/src/DataModel/Collections/TypesCollection.ts
@@ -1,30 +1,28 @@
+import FilterableCollection from "./FilterableCollection";
+
 /**
  * Provides a collection of types that can be filtered with relevant criteria.
  * @class
  */
-export default class TypesCollection extends Array<string> {
+export default class TypesCollection extends FilterableCollection<string> {
   /**
    * Initializes a new instance of the {@link TypesCollection} class with initial collections of types to filter.
-   * @param types {Iterable<string> | Array<string>} Initial collection of types to filter.
+   * @param types {Iterable<string>} Initial collection of types to filter.
    */
-  public constructor(types: Iterable<string> | string[]);
-
-  /**
-   * Initializes a new instance of the {@link TypesCollection} class with initial collections of types to filter.
-   * @param types {...string} Initial collection of types to filter.
-   */
-  public constructor(...types: string[]);
-
-  public constructor(types: any) {
-    super(...types);
+  public constructor(types: Iterable<string>) {
+    super(types);
   }
 
   /**
-   * Checks whether this collection has a given type
-   * @param type {string} Type name.
+   * Checks whether this collection has a given type.
+   * @param type {string} Type to look for.
    * @returns {boolean}
    */
   public contains(type: string): boolean {
-    return this.indexOf(type) !== -1;
+    return this.where(item => item === type).any();
+  }
+
+  protected createInstance(items: Iterable<string>): TypesCollection {
+    return new TypesCollection(items);
   }
 }

--- a/tests/DataModel/TemplatedLink.spec.ts
+++ b/tests/DataModel/TemplatedLink.spec.ts
@@ -1,8 +1,10 @@
 import TemplatedLink from "../../src/DataModel/TemplatedLink";
 import { hydra } from "../../src/namespaces";
+import HydraResourceMatcher from "../../testing/HydraResourceMatcher";
 
 describe("Given instance of the TemplatedLink", () => {
   beforeEach(() => {
+    jasmine.addMatchers({ toBeLike: () => new HydraResourceMatcher() });
     this.template = {
       template: "some-uri{?with-variable}"
     };
@@ -16,7 +18,7 @@ describe("Given instance of the TemplatedLink", () => {
   });
 
   it("should provide link of correct type", () => {
-    expect(this.link.type).toEqual([hydra.TemplatedLink]);
+    expect([...this.link.type]).toEqual([hydra.TemplatedLink]);
   });
 
   describe("when expanding URI with variable values", () => {
@@ -25,11 +27,11 @@ describe("Given instance of the TemplatedLink", () => {
     });
 
     it("should provide an expanded URL", () => {
-      expect(this.result.target).toEqual({ iri: "http://temp.uri/some-uri?with-variable=test-value", type: [] });
+      expect(this.result.target).toBeLike({ iri: "http://temp.uri/some-uri?with-variable=test-value", type: [] });
     });
 
     it("should copy original operation's types", () => {
-      expect(this.result.type).toEqual([hydra.Link]);
+      expect([...this.result.type]).toEqual([hydra.Link]);
     });
   });
 });

--- a/tests/DataModel/TemplatedOperation.spec.ts
+++ b/tests/DataModel/TemplatedOperation.spec.ts
@@ -2,9 +2,11 @@ import ResourceFilterableCollection from "../../src/DataModel/Collections/Resour
 import { IClass } from "../../src/DataModel/IClass";
 import TemplatedOperation from "../../src/DataModel/TemplatedOperation";
 import { hydra } from "../../src/namespaces";
+import HydraResourceMatcher from "../../testing/HydraResourceMatcher";
 
 describe("Given instance of the TemplatedOperation", () => {
   beforeEach(() => {
+    jasmine.addMatchers({ toBeLike: () => new HydraResourceMatcher() });
     this.template = {
       template: "some-uri{?with-variable}"
     };
@@ -24,7 +26,7 @@ describe("Given instance of the TemplatedOperation", () => {
     });
 
     it("should provide an expanded URL", () => {
-      expect(this.result.target).toEqual({ iri: "http://temp.uri/some-uri?with-variable=test-value", type: [] });
+      expect(this.result.target).toBeLike({ iri: "http://temp.uri/some-uri?with-variable=test-value", type: [] });
     });
 
     it("should pass a correct method", () => {
@@ -32,7 +34,7 @@ describe("Given instance of the TemplatedOperation", () => {
     });
 
     it("should copy original operation's types", () => {
-      expect(this.result.type).toEqual(["http://schema.org/AddAction", hydra.Operation]);
+      expect([...this.result.type]).toEqual(["http://schema.org/AddAction", hydra.Operation]);
     });
   });
 });


### PR DESCRIPTION
I did remove Array inheritance in the TypesCollection in favor of the FilterableCollection we're using across the client. It may be a breaking change as the `type` property's API will change as it won't be an Array any more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hydracg/heracles.ts/28)
<!-- Reviewable:end -->
