### PR TITLE
Added ability to inject custom HTTP call facility

### DIFF
--- a/tests/HydraClient.spec.ts
+++ b/tests/HydraClient.spec.ts
@@ -14,8 +14,8 @@ describe("Given an instance of the HydraClient class", () => {
         response.headers.get("Content-Type") === "application/ld+json" ? Level.FullSupport : Level.None
     };
     this.iriTemplateExpansionStrategy = {};
-    this.client = new HydraClient([this.hypermediaProcessor], this.iriTemplateExpansionStrategy);
-    this.fetch = sinon.stub(window, "fetch");
+    this.fetch = sinon.stub();
+    this.client = new HydraClient([this.hypermediaProcessor], this.iriTemplateExpansionStrategy, this.fetch);
   });
 
   it("should create an instance", () => {
@@ -321,9 +321,5 @@ describe("Given an instance of the HydraClient class", () => {
         })
       );
     });
-  });
-
-  afterEach(() => {
-    this.fetch.restore();
   });
 });


### PR DESCRIPTION
As in the title. While Heracles.ts will use `fetch` by default, it is possible to come with a custom HTTP facility matching a specified signature so it will be possible to intercept calls made byte the client.

Please note this will not affect the underlying json-ld API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hydracg/heracles.ts/54)
<!-- Reviewable:end -->
